### PR TITLE
Update theme.dart, Deprecated text styles need updating

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -8,16 +8,16 @@ var appTheme = ThemeData(
   ),
   brightness: Brightness.dark,
   textTheme: const TextTheme(
-    bodyText1: TextStyle(fontSize: 18),
-    bodyText2: TextStyle(fontSize: 16),
-    button: TextStyle(
+    bodyLarge: TextStyle(fontSize: 18),
+    bodyMedium: TextStyle(fontSize: 16),
+    labelLarge: TextStyle(
       letterSpacing: 1.5,
       fontWeight: FontWeight.bold,
     ),
-    headline1: TextStyle(
+    displayLarge: TextStyle(
       fontWeight: FontWeight.bold,
     ),
-    subtitle1: TextStyle(
+    titleMedium: TextStyle(
       color: Colors.grey,
     ),
   ),


### PR DESCRIPTION
The original bodyText1, bodyText2, button, subtitle1 use deprecated values and give this error: 

'bodyText1' is deprecated and shouldn't be used. Use bodyLarge instead. This feature was deprecated after v3.1.0-0.0.pre. Try replacing the use of the deprecated member with the replacement.

I changed all text styles to accurate values now, using bodyLarge, bodyMedium, labelLarge, displayLarge, and titleMedium.